### PR TITLE
Refactor email asset URL configuration

### DIFF
--- a/src/config/emailAssets.ts
+++ b/src/config/emailAssets.ts
@@ -3,11 +3,20 @@
  * These URLs point to the hosted images on the backend server
  */
 
-const BACKEND_URL =
-  process.env.REACT_APP_BACKEND_URL_DEVELOPMENT ||
-  process.env.REACT_APP_BACKEND_URL_PRODUCTION ||
-  // "http://192.168.100.56:5001";
-  "https://api.freespeek.net/api";
+// Get the base backend URL (without /api suffix) for assets
+const getBackendBaseUrl = () => {
+  const devUrl = process.env.REACT_APP_BACKEND_URL_DEVELOPMENT;
+  const prodUrl = process.env.REACT_APP_BACKEND_URL_PRODUCTION;
+
+  // Remove /api suffix if present
+  const baseUrl = (prodUrl || devUrl || "https://api.freespeek.net").replace(
+    /\/api$/,
+    ""
+  );
+  return baseUrl;
+};
+
+const BACKEND_URL = getBackendBaseUrl();
 export const EMAIL_ASSETS = {
   LOGO: `${BACKEND_URL}/assets/email-templates/freespeek-logo.png`,
   APP_STORE_BUTTON: `${BACKEND_URL}/assets/email-templates/app-store-button.jpg`,


### PR DESCRIPTION
- Introduced a function to dynamically retrieve the backend base URL for email assets, removing the hardcoded URL.
- Ensured the URL is stripped of the /api suffix if present, improving flexibility for different environments.